### PR TITLE
Remove Float16Array dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@petamoriken/float16": "^3.8.1",
     "@radix-ui/colors": "^1.0.0",
     "@radix-ui/react-select": "^1.2.2",
     "autoprefixer": "^10.4.14",

--- a/src/lib/parseHDR.ts
+++ b/src/lib/parseHDR.ts
@@ -1,5 +1,5 @@
 // Based on https://github.com/vorg/parse-hdr
-import { Float16Array } from "@petamoriken/float16";
+import {toHalf} from "./toHalf";
 
 let radiancePattern = "#\\?RADIANCE";
 let commentPattern = "#.*";
@@ -59,7 +59,7 @@ export async function parseHDR(url: string) {
 
   readPixelsRawRLE(buffer, data, 0, fileOffset, scanlineWidth, scanlinesCount);
 
-  let floatData = new Float16Array(width * height * 4);
+  let floatData = new Uint16Array(width * height * 4);
   for (let offset = 0; offset < data.length; offset += 4) {
     let r = data[offset + 0] / 255;
     let g = data[offset + 1] / 255;
@@ -73,9 +73,9 @@ export async function parseHDR(url: string) {
 
     let floatOffset = offset;
 
-    floatData[floatOffset + 0] = r;
-    floatData[floatOffset + 1] = g;
-    floatData[floatOffset + 2] = b;
+    floatData[floatOffset + 0] = toHalf(r);
+    floatData[floatOffset + 1] = toHalf(g);
+    floatData[floatOffset + 2] = toHalf(b);
     floatData[floatOffset + 3] = 1.0;
   }
 

--- a/src/lib/toHalf.ts
+++ b/src/lib/toHalf.ts
@@ -1,0 +1,41 @@
+// https://stackoverflow.com/questions/32633585/how-do-you-convert-to-half-floats-in-javascript
+const floatView = new Float32Array(1);
+const int32View = new Int32Array(floatView.buffer);
+export function toHalf(val: number) {
+  floatView[0] = val;
+  var x = int32View[0];
+
+  var bits = (x >> 16) & 0x8000; /* Get the sign */
+  var m = (x >> 12) & 0x07ff; /* Keep one extra bit for rounding */
+  var e = (x >> 23) & 0xff; /* Using int is faster here */
+
+  /* If zero, or denormal, or exponent underflows too much for a denormal
+   * half, return signed zero. */
+  if (e < 103) {
+    return bits;
+  }
+
+  /* If NaN, return NaN. If Inf or exponent overflow, return Inf. */
+  if (e > 142) {
+    bits |= 0x7c00;
+    /* If exponent was 0xff and one mantissa bit was set, it means NaN,
+     * not Inf, so make sure we set one mantissa bit too. */
+    bits |= (e == 255 ? 0 : 1) && x & 0x007fffff;
+    return bits;
+  }
+
+  /* If exponent underflows but not too much, return a denormal */
+  if (e < 113) {
+    m |= 0x0800;
+    /* Extra rounding may overflow and set mantissa to 0 and exponent
+     * to 1, which is OK. */
+    bits |= (m >> (114 - e)) + ((m >> (113 - e)) & 1);
+    return bits;
+  }
+
+  bits |= ((e - 112) << 10) | (m >> 1);
+  /* Extra rounding. An overflow will set mantissa to 0 and increment
+   * the exponent, which is OK. */
+  bits += m & 1;
+  return bits;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,11 +201,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@petamoriken/float16@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@petamoriken/float16/-/float16-3.8.1.tgz#ebb6994fb7b0698fc73e11a183a2b5e3ae722fb4"
-  integrity sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg==
-
 "@radix-ui/colors@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/colors/-/colors-1.0.0.tgz#3ec423748d5ba8f5ae9e2ad1b91c796c726dc000"


### PR DESCRIPTION
The @petamoriken/float16 Float16Array is very slow. Converting the float to a half manually and storing it in a Uint16Array is about 10x faster.

This repository is a top result on Google for "WebGPU IBL", so hopefully this is useful to anyone else that wants to borrow your code, especially the .hdr image loader.